### PR TITLE
Generate placeholder textures when art is missing

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Alaskan Frontier: Prototype</title>
+  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
+  <script src="https://cdn.jsdelivr.net/npm/phaser@3.60.0/dist/phaser.min.js"></script>
+  <style>
+    html,body{height:100%;margin:0}
+    body{
+      background:#0d1117; color:#e6edf3;
+      display:flex; align-items:center; justify-content:center;
+      font-family: "Press Start 2P", system-ui, sans-serif;
+    }
+    #game-container{ box-shadow:0 0 24px rgba(0,0,0,.45) }
+  </style>
+</head>
+<body>
+  <div id="game-container"></div>
+  <script type="module" src="scripts/main.js"></script>
+</body>
+</html>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,0 +1,15 @@
+import PreloadScene from './scenes/PreloadScene.js';
+import GameScene    from './scenes/GameScene.js';
+import UIScene      from './scenes/UIScene.js';
+
+const config = {
+  type: Phaser.AUTO,
+  width: 800, height: 600,
+  parent: 'game-container',
+  backgroundColor: '#000000',
+  pixelArt: true,
+  scene: [PreloadScene, GameScene, UIScene],
+  physics: { default: 'arcade', arcade: { debug: false, gravity: { y: 0 } } }
+};
+
+window.game = new Phaser.Game(config);

--- a/scripts/scenes/GameScene.js
+++ b/scripts/scenes/GameScene.js
@@ -1,0 +1,46 @@
+export default class GameScene extends Phaser.Scene {
+  constructor(){ super({ key:'GameScene' }); }
+
+  create(){
+    // Background (scaled to fit)
+    const bg = this.add.image(400, 300, 'background').setDepth(0);
+    const scaleX = this.cameras.main.width / bg.width;
+    const scaleY = this.cameras.main.height / bg.height;
+    const scale = Math.max(scaleX, scaleY);
+    bg.setScale(scale).setScrollFactor(0);
+
+    // Player
+    this.player = this.physics.add.sprite(400, 300, 'player')
+      .setDepth(1).setCollideWorldBounds(true);
+
+    // A single interactive (the “bush”)
+    this.bush = this.add.image(600, 420, 'bush').setDepth(1).setScale(0.5).setInteractive();
+
+    // Click bush -> if close enough, "collect berries"
+    this.bush.on('pointerdown', () => {
+      const d = Phaser.Math.Distance.Between(this.player.x, this.player.y, this.bush.x, this.bush.y);
+      if (d < 110) {
+        const p = this.registry.get('player');
+        p.hunger = Math.max(0, p.hunger - 20);
+        this.registry.set('player', p);
+        this.game.events.emit('showMessage', 'You found berries.');
+      } else {
+        this.game.events.emit('showMessage', 'Too far away.');
+      }
+    });
+
+    // Click anywhere else to move
+    this.input.on('pointerdown', (pointer) => {
+      const hits = this.input.hitTestPointer(pointer);
+      const clickedInteractive = hits.some(obj => obj === this.bush);
+      if (!clickedInteractive) this.movePlayer(pointer.x, pointer.y);
+    });
+
+    // Launch UI overlay
+    this.scene.launch('UIScene');
+  }
+
+  movePlayer(x, y){
+    this.tweens.add({ targets:this.player, x, y, duration:600, ease:'Power2' });
+  }
+}

--- a/scripts/scenes/PreloadScene.js
+++ b/scripts/scenes/PreloadScene.js
@@ -1,0 +1,58 @@
+export default class PreloadScene extends Phaser.Scene {
+  constructor(){ super({ key:'PreloadScene' }); }
+
+  preload(){
+    const cx = this.cameras.main.centerX, cy = this.cameras.main.centerY;
+    this.add.text(cx, cy, 'Loading...', { font:'16px Arial', fill:'#fff' }).setOrigin(.5);
+
+    // Try loading images (fine if they 404)
+    this.load.image('background', 'assets/images/wilderness_bg.png');
+    this.load.image('player',     'assets/images/player.png');
+    this.load.image('bush',       'assets/images/wilderness_NEWONE.png');
+    this.load.image('ui_panel',   'assets/images/ui_panel.png');
+
+    this.load.on('loaderror', (f)=>console.warn('Missing asset -> using placeholder:', f.key));
+  }
+
+  create(){
+    // Generate placeholders for any missing textures
+    const ensure = (key, drawFn) => {
+      if (!this.textures.exists(key)) {
+        const g = this.add.graphics();
+        drawFn(g);
+        // Size from the last draw; provide explicit sizes
+        const b = g.getBounds();
+        const w = Math.max(1, Math.ceil(b.width));
+        const h = Math.max(1, Math.ceil(b.height));
+        g.generateTexture(key, w, h);
+        g.destroy();
+      }
+    };
+
+    ensure('background', (g)=>{
+      g.fillStyle(0x1f3b2d, 1); g.fillRect(0,0,800,600);
+      g.lineStyle(2,0x0e2219,1);
+      for(let x=0;x<=800;x+=40){ g.lineBetween(x,0,x,600); }
+      for(let y=0;y<=600;y+=40){ g.lineBetween(0,y,800,y); }
+    });
+
+    ensure('player', (g)=>{
+      g.fillStyle(0xffe17a,1); g.fillCircle(12,12,12);
+      g.lineStyle(3,0x333333,1); g.strokeCircle(12,12,12);
+    });
+
+    ensure('bush', (g)=>{
+      g.fillStyle(0x2fa872,1); g.fillCircle(30,24,24);
+      g.fillStyle(0x1e7a53,1); g.fillCircle(18,28,16);
+      g.fillStyle(0x3ac084,1); g.fillCircle(42,28,16);
+    });
+
+    ensure('ui_panel', (g)=>{
+      g.fillStyle(0x000000,0.7); g.fillRoundedRect(0,0,200,80,8);
+      g.lineStyle(2,0xffffff,0.8); g.strokeRoundedRect(0,0,200,80,8);
+    });
+
+    this.registry.set('player', { health:100, hunger:0, cold:0 });
+    this.scene.start('GameScene');
+  }
+}

--- a/scripts/scenes/UIScene.js
+++ b/scripts/scenes/UIScene.js
@@ -1,0 +1,33 @@
+export default class UIScene extends Phaser.Scene {
+  constructor(){ super({ key:'UIScene' }); }
+
+  create(){
+    // Status bars (simple)
+    this.labels = this.add.text(16, 16, '', { font:'14px Arial', fill:'#fff' }).setDepth(10);
+    this.updateLabels(this.registry.get('player'));
+
+    // Transient message at top-center
+    this.msg = this.add.text(this.scale.width/2, 40, '', {
+      font:'16px Arial', fill:'#fff', backgroundColor:'#000', padding:{ x:10, y:6 }
+    }).setOrigin(.5).setAlpha(0).setDepth(20);
+
+    // Listen for changes + messages
+    this.registry.events.on('changedata', (parent, key, val) => {
+      if (key === 'player') this.updateLabels(val);
+    });
+    this.game.events.on('showMessage', (text) => this.showMessage(text));
+  }
+
+  updateLabels(p){
+    this.labels.setText([
+      `Health: ${p.health}`,
+      `Hunger: ${p.hunger}`,
+      `Cold:   ${p.cold}`
+    ].join('\n'));
+  }
+
+  showMessage(text){
+    this.msg.setText(text).setAlpha(1);
+    this.tweens.add({ targets:this.msg, alpha:0, delay:900, duration:500, ease:'Power1' });
+  }
+}


### PR DESCRIPTION
## Summary
- warn when image loads fail and fall back to generated textures
- draw simple procedural placeholders for the background, player, bush, and UI panel
- keep the registry bootstrap before handing off to the game scene

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cae5cfeea48332879f9fa71147f1b5